### PR TITLE
Update android manifest for module api version change

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,9 +2,9 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.3.0
-apiversion: 2
-architectures: armeabi armeabi-v7a x86
+version: 2.0.0
+apiversion: 3
+architectures: armeabi-v7a x86
 description: UrbanAirship Titanium module
 author: Urban Airship
 license: Apache License, Version 2.0
@@ -15,5 +15,5 @@ name: UrbanAirship
 moduleid: com.urbanairship
 guid: 240dc468-ccad-479d-9510-14e9a7cae5c9
 platform: android
-minsdk: 5.2.2.GA
+minsdk: 6.0.0
 respackage: com.urbanairship


### PR DESCRIPTION
Hey guys, Titanium 6 will introduce a breaking change to Android modules, as a result of upgrading the V8 engine used. Going from 5.x to 6.x, the module apiversion will be bumped from 2 to 3, "armeabi" ABI will be removed and modules will need to be rebuilt against a 6.0.0+ version of the SDK.

These changes are basically all that are needed in terms of the your module. Then you'll need to grab a 6.0.0/master build of the SDK:
`appc ti sdk install -b master`

And point your build.properties at that version, then just re-run `ant` to build a new android module zip.
