### PR TITLE
[MB-1974] iOS foreground presentation support.

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -30,6 +30,13 @@ Modify the `tiapp.xml` file to include the Urban Airship Config:
   <property name="com.urbanairship.gcm_sender" type="String">GCM Sender ID or Project Number</property>
   <property name="com.urbanairship.notification_icon" type="string">Name of an icon in /project_name/platform/android/res/drawable folders, e.g. ic_notification.png</property>
   <property name="com.urbanairship.notification_accent_color" type="string">Notification accent color, e.g. #ff0000</property>
+
+  <!-- iOS 10 alert foreground notification presentation option -->
+  <property name="com.urbanairship.ios_foreground_notification_presentation_alert" type="bool">true</property>
+  <!-- iOS 10 badge foreground notification presentation option -->
+  <property name="com.urbanairship.ios_foreground_notification_presentation_badge" type="bool">true</property>
+  <!-- iOS 10 sound foreground notification presentation option -->
+  <property name="com.urbanairship.ios_foreground_notification_presentation_sound" type="bool">true</property>
 ```
 
 For iOS, enable background remote notifications in the `tiapp.xml` file:

--- a/ios/Classes/ComUrbanairshipAutopilot.m
+++ b/ios/Classes/ComUrbanairshipAutopilot.m
@@ -20,6 +20,9 @@ NSString *const ProductionAppSecretConfigKey = @"com.urbanairship.production_app
 NSString *const DevelopmentAppKeyConfigKey = @"com.urbanairship.development_app_key";
 NSString *const DevelopmentAppSecretConfigKey = @"com.urbanairship.development_app_secret";
 NSString *const ProductionConfigKey = @"com.urbanairship.in_production";
+NSString *const NotificationPresentationAlertKey = @"com.urbanairship.ios_foreground_notification_presentation_alert";
+NSString *const NotificationPresentationBadgeKey = @"com.urbanairship.ios_foreground_notification_presentation_badge";
+NSString *const NotificationPresentationSoundKey = @"com.urbanairship.ios_foreground_notification_presentation_sound";
 
 + (NSBundle *)resources {
     static dispatch_once_t resourceDispatchOnceToken_;
@@ -87,6 +90,30 @@ NSString *const ProductionConfigKey = @"com.urbanairship.in_production";
     config.developmentAppSecret = appProperties[DevelopmentAppSecretConfigKey];
     config.inProduction = [appProperties[ProductionConfigKey] boolValue];
     [UAirship takeOff:config];
+
+    // Set the iOS default foreground presentation options if specified in the tiapp.xml else default to None
+    UNNotificationPresentationOptions options = UNNotificationPresentationOptionNone;
+
+    if (appProperties[NotificationPresentationAlertKey]) {
+        if ([appProperties[NotificationPresentationAlertKey] boolValue]) {
+            options = options | UNNotificationPresentationOptionAlert;
+        }
+    }
+
+    if (appProperties[NotificationPresentationBadgeKey] != nil) {
+        if ([appProperties[NotificationPresentationBadgeKey] boolValue]) {
+            options = options | UNNotificationPresentationOptionBadge;
+        }
+    }
+
+    if (appProperties[NotificationPresentationSoundKey] != nil) {
+        if ([appProperties[NotificationPresentationSoundKey] boolValue]) {
+            options = options | UNNotificationPresentationOptionSound;
+        }
+    }
+
+    UA_LDEBUG(@"Foreground presentation options: %lu", (unsigned long)options);
+    [UAirship push].defaultPresentationOptions = options;
 }
 
 

--- a/ios/Classes/ComUrbanairshipModule.m
+++ b/ios/Classes/ComUrbanairshipModule.m
@@ -31,6 +31,7 @@
 - (void)receivedNotificationResponse:(UANotificationResponse *)notificationResponse completionHandler:(void(^)())completionHandler {
     UA_LDEBUG(@"The application was launched or resumed from a notification %@", notificationResponse);
     self.launchPush = notificationResponse.notificationContent.notificationInfo;
+    completionHandler();
 }
 
 - (void)receivedForegroundNotification:(UANotificationContent *)notificationContent completionHandler:(void(^)())completionHandler {
@@ -43,6 +44,7 @@
     [data setValue:[ComUrbanairshipModule extrasForUserInfo:notificationContent.notificationInfo] forKey:@"extras"];
 
     [self fireEvent:self.EVENT_PUSH_RECEIVED withObject:data];
+    completionHandler();
 }
 
 #pragma mark UARegistrationDelegate


### PR DESCRIPTION
Added iOS 10 foreground presentation support.

Specify the optional default foreground presentation options for iOS 10 via the `tiapp.xml`:

```
<!-- iOS 10 alert foreground notification presentation option -->
<property name="com.urbanairship.ios_foreground_notification_presentation_alert" type="bool">true</property>
<!-- iOS 10 badge foreground notification presentation option -->
<property name="com.urbanairship.ios_foreground_notification_presentation_badge" type="bool">true</property>
<!-- iOS 10 sound foreground notification presentation option -->
<property name="com.urbanairship.ios_foreground_notification_presentation_sound" type="bool">true</property>
```

Testing:
- Tested foreground notification presentation options on iOS 10.0.2 iPod
