### PR TITLE
[MB-1978] Added support for associated identifiers.

### DIFF
--- a/android/src/com/urbanairship/ti/UrbanAirshipModule.java
+++ b/android/src/com/urbanairship/ti/UrbanAirshipModule.java
@@ -93,6 +93,22 @@ public class UrbanAirshipModule extends KrollModule {
         UAirship.shared().getPushManager().getNamedUser().setId(namedUser);
     }
 
+    @Kroll.method
+    public void associateIdentifier(String key, String identifier) {
+        if (key == null) {
+            Log.d(TAG, "AssociateIdentifier failed, key cannot be null.");
+            return;
+        }
+
+        if (identifier == null) {
+            Log.d(TAG, "AssociateIdentifier removed identifier for key: " + key);
+            UAirship.shared().getAnalytics().editAssociatedIdentifiers().removeIdentifier(key).apply();
+        } else {
+            Log.d(TAG, "AssociateIdentifier with identifier: " + identifier + " for key: " + key);
+            UAirship.shared().getAnalytics().editAssociatedIdentifiers().addIdentifier(key, identifier).apply();
+        }
+    }
+
     @Kroll.method 
     @Kroll.getProperty
     public Object[] getTags() {

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -151,3 +151,14 @@ Displays the message center.
     UrbanAirship.displayMessageCenter();
 ```
 
+### associateIdentifier(key, identifier)
+
+Associate a custom identifier.
+Previous identifiers will be replaced by the new identifiers each time associateIdentifier is called.
+It is a set operation.
+ - key: The custom key for the identifier as a string.
+ - identifier: The value of the identifier as a string, or `null` to remove the identifier.
+
+```
+    UrbanAirship.associateIdentifier("customKey", "customIdentifier");
+```

--- a/example/app.js
+++ b/example/app.js
@@ -178,6 +178,9 @@ UrbanAirship.namedUser = "namedUser";
 Ti.API.info("namedUser: " + UrbanAirship.namedUser);
 namedUserLabel.text = UrbanAirship.namedUser;
 
+// Add a custom identifier
+UrbanAirship.associateIdentifier("customKey", "customIdentifier");
+
 // Set Tags
 UrbanAirship.tags = [ osname, 'titanium-test' ];
 var data = UrbanAirship.tags;

--- a/ios/Classes/ComUrbanairshipModule.m
+++ b/ios/Classes/ComUrbanairshipModule.m
@@ -7,6 +7,7 @@
 #import "TiHost.h"
 #import "TiUtils.h"
 #import "AirshipLib.h"
+#import "UAAssociatedIdentifiers.h"
 
 @interface ComUrbanairshipModule()
 @property (nonatomic, copy) NSDictionary *launchPush;
@@ -121,6 +122,29 @@
 - (void)setNamedUser:(id)value {
     ENSURE_STRING(value);
     [UAirship namedUser].identifier = [value length] ? value : nil;
+}
+
+- (void)associateIdentifier:(id)args {
+    ENSURE_ARRAY(args);
+
+    NSString *keyString = [TiUtils stringValue:[args objectAtIndex:0]];
+
+    if (keyString.length == 0) {
+        UA_LDEBUG(@"AssociateIdentifier failed, key cannot be nil.");
+        return;
+    }
+
+    NSString *identifierString = [TiUtils stringValue:[args objectAtIndex:1]];
+
+    if (identifierString.length == 0) {
+        UA_LDEBUG(@"AssociateIdentifier removed identifier for key: %@", keyString);
+    } else {
+        UA_LDEBUG(@"AssociateIdentifier with identifier: %@ for key: %@", identifierString, keyString);
+    }
+
+    UAAssociatedIdentifiers *identifiers = [[UAirship shared].analytics currentAssociatedDeviceIdentifiers];
+    [identifiers setIdentifier:identifierString forKey:keyString];
+    [[UAirship shared].analytics associateDeviceIdentifiers:identifiers];
 }
 
 - (NSDictionary *)getLaunchNotification:(id)args {


### PR DESCRIPTION
Added `associatedIdentifier` method to set custom identifiers.

Testing:
Verified associate_identifiers events in logs for both android and iOS.

```
UrbanAirship.associateIdentifier("ice", "cream");
UrbanAirship.associateIdentifier("friend", "ship");
UrbanAirship.associateIdentifier(null, "ship");     // invalid null key
UrbanAirship.associateIdentifier("friend", null);   // removes identifier for key 'friend'
```
