### PR TITLE
[MB-1977] Add custom event support.

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -169,3 +169,29 @@ It is a set operation.
 ```
     UrbanAirship.associateIdentifier("customKey", "customIdentifier");
 ```
+
+### addCustomEvent(eventPayload)
+
+Adds a custom event.
+ - eventPayload: The custom event payload as a string.
+
+```
+    var customEvent = {
+      event_name: 'customEventName',
+      event_value: 2016,
+      transaction_id: 'customTransactionId',
+      interaction_id: 'customInteractionId',
+      interaction_type: 'customInteractionType',
+      properties: {
+        someBoolean: true,
+        someDouble: 124.49,
+        someString: "customString",
+        someInt: 5,
+        someLong: 1234567890,
+        someArray: ["tangerine", "pineapple", "kiwi"]
+      }
+    };
+
+    var customEventPayload = JSON.stringify(customEvent);
+    UrbanAirship.addCustomEvent(customEventPayload);
+```

--- a/example/app.js
+++ b/example/app.js
@@ -181,6 +181,26 @@ namedUserLabel.text = UrbanAirship.namedUser;
 // Add a custom identifier
 UrbanAirship.associateIdentifier("customKey", "customIdentifier");
 
+// Add a custom event
+var customEvent = {
+    event_name: 'customEventName',
+    event_value: 2016,
+    transaction_id: 'customTransactionId',
+    interaction_id: 'customInteractionId',
+    interaction_type: 'customInteractionType',
+    properties: {
+        someBoolean: true,
+        someDouble: 124.49,
+        someString: "customString",
+        someInt: 5,
+        someLong: 1234567890,
+        someArray: ["tangerine", "pineapple", "kiwi"]
+    }
+};
+
+var customEventPayload = JSON.stringify(customEvent);
+UrbanAirship.addCustomEvent(customEventPayload);
+
 // Set Tags
 UrbanAirship.tags = [ osname, 'titanium-test' ];
 var data = UrbanAirship.tags;

--- a/ios/Classes/ComUrbanairshipModule.m
+++ b/ios/Classes/ComUrbanairshipModule.m
@@ -149,6 +149,21 @@
     [[UAirship shared].analytics associateDeviceIdentifiers:identifiers];
 }
 
+- (void)addCustomEvent:(id)eventPayload {
+    NSString *customEventString = [TiUtils stringValue:[eventPayload objectAtIndex:0]];
+    UA_LDEBUG(@"Add custom event: %@", customEventString);
+
+    if (customEventString.length == 0) {
+        UA_LERR(@"Missing event payload.");
+        return;
+    }
+
+    NSError *jsonError;
+    NSData *data = [customEventString dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *eventArgs = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&jsonError];
+    [UAActionRunner runActionWithName:@"add_custom_event_action" value:eventArgs situation:UASituationManualInvocation];
+}
+
 - (NSDictionary *)getLaunchNotification:(id)args {
     NSString *incomingAlert = @"";
     NSMutableDictionary *incomingExtras = [NSMutableDictionary dictionary];


### PR DESCRIPTION
Add support for custom events.

Testing:
Tested on android 7.0 nexus 5x and iOS 10.0.2 iPod touch and verified custom events added via log.
```
// app.js
var customEvent = {
	event_name: 'customEventName',
	event_value: 2016,
	transaction_id: 'customTransactionId',
	interaction_id: 'customInteractionId',
	interaction_type: 'customInteractionType',
	properties: {
		someBoolean: true,
		someDouble: 124.49,
		someString: "customString",
		someInt: 5,
		someLong: 1234567890,
		someArray: ["tangerine", "pineapple", "kiwi"]
	}
};

var customEventPayload = JSON.stringify(customEvent);
UrbanAirship.addCustomEvent(customEventPayload);
```