### PR TITLE
[MB-2064] Update to Titanium 6.0.0 GA

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,9 +2,9 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.2
-apiversion: 2
-architectures: armeabi armeabi-v7a x86
+version: 3.0.0
+apiversion: 3
+architectures: armeabi-v7a x86
 description: UrbanAirship Titanium module
 author: Urban Airship
 license: Apache License, Version 2.0
@@ -15,5 +15,5 @@ name: UrbanAirship
 moduleid: com.urbanairship
 guid: 240dc468-ccad-479d-9510-14e9a7cae5c9
 platform: android
-minsdk: 5.5.0.GA
+minsdk: 6.0.0.GA
 respackage: com.urbanairship

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,6 +1,13 @@
 Urban Airship Titanium Module
 =============================
 
+Version 3.0.0 - November 21, 2016
+=================================
+ - Update to Titanium 6.0.0 GA.
+ - Added iOS foreground presentation support.
+ - Added support for associated identifiers.
+ - Added support for custom events.
+
 Version 2.0.2 - November 21, 2016
 =================================
  - Fixed getLaunchNotification on iOS not returning the notification when app is started from a push notification.

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.2
+version: 3.0.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: UrbanAirship Titanium module
@@ -15,4 +15,4 @@ name: UrbanAirship
 moduleid: com.urbanairship
 guid: 240dc468-ccad-479d-9510-14e9a7cae5c9
 platform: iphone
-minsdk: 5.5.0.GA
+minsdk: 6.0.0.GA


### PR DESCRIPTION
Release 3.0.0:
* Update to Titanium 6.0.0 GA (This is a breaking change to the Android modules)

Testing:
* Received push notifications on android 7.0 nexus 5x and iOS 10.1.1 iPod

Todo:
* Update Jenkins build machine to Titanium 6.0.0 GA
