### PR TITLE
[GH-29] release 4.0.1

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.0.0
+version: 4.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: Urban Airship Titanium module

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,6 +1,10 @@
 Urban Airship Titanium Module
 =============================
 
+Version 4.0.1 - April 6, 2018
+=============================
+- Fixed bug causing iOS resource bundle verification errors.
+
 Version 4.0.0 - February 6, 2018
 ================================
  - Update to Titanium 7.0.1

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.0.0
+version: 4.0.1
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: Urban Airship Titanium module


### PR DESCRIPTION
It looks as though titanium, as of version 7.0, has been mangling our AirshipResources bundle and sticking an executable in there, which breaks app submissions. I'm going to make another ticket to actually fix this properly in the tooling (probably just an extra script for post-processing the generated module) but to get a fix out quickly for right now the idea is just to delete the spurious executable from the bundle and re-zip it before publishing.

So this PR is just to bump the versions. Please don't do any jenkins promotion, so that I can build and upload the artifacts manually.