### PR TITLE
[MOBILE-1648] Tag editors

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -5,6 +5,8 @@ Module uses a makefile for build and install commands:
 - `build-android`: Builds the Android module
 - `build-ios`: Builds the iOS module
 - `install`: Builds both modules and unpacks the zips into the titanium module directory
+- `install-android`: Builds and unpacks the Android zip into the titanium module directory
+- `install-ios`:  Builds and unpacks the iOS zip into the titanium module directory
 - `clean`: Cleans any build folders
 
 ## Updating SDKs

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,13 @@ build-android:
 build-ios:
 	bash ./scripts/build_ios.sh
 
-install: build
-	unzip -o ios/dist/ti.airship-iphone-*.zip -d ~/Library/Application\ Support/Titanium/
+install: install-ios install-android
+
+install-android: build-android
 	unzip -o android/dist/ti.airship-android-*.zip -d ~/Library/Application\ Support/Titanium/
+
+install-ios: build-ios
+	unzip -o ios/dist/ti.airship-iphone-*.zip -d ~/Library/Application\ Support/Titanium/
 
 clean:
 	rm -rf android/build

--- a/android/src/ti/airship/AirshipTitaniumModule.java
+++ b/android/src/ti/airship/AirshipTitaniumModule.java
@@ -1,6 +1,6 @@
 /* Copyright Airship and Contributors */
 
-package com.urbanairship.ti;
+package ti.airship;
 
 import com.urbanairship.Autopilot;
 import com.urbanairship.UAirship;
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 @Kroll.module(name = "AirshipTitanium", id = "ti.airship")
-public class UrbanAirshipModule extends KrollModule {
+public class AirshipTitaniumModule extends KrollModule {
 
     @Kroll.constant
     public static final String EVENT_CHANNEL_UPDATED = "EVENT_CHANNEL_UPDATED";
@@ -34,7 +34,7 @@ public class UrbanAirshipModule extends KrollModule {
     @Kroll.constant
     public static final String EVENT_PUSH_RECEIVED = "PUSH_RECEIVED";
 
-    private static final String TAG = "UrbanAirshipModule";
+    public static final String TAG = "AirshipTitaniumModule";
 
     private static final String MODULE_NAME = "AirshipTitanium";
 
@@ -43,7 +43,7 @@ public class UrbanAirshipModule extends KrollModule {
     private static Integer launchNotificationId = null;
     private static String deepLink = null;
 
-    public UrbanAirshipModule() {
+    public AirshipTitaniumModule() {
         super(MODULE_NAME);
     }
 
@@ -178,7 +178,7 @@ public class UrbanAirshipModule extends KrollModule {
     }
 
     public static void onPushReceived(PushMessage message, Integer notificationId) {
-        UrbanAirshipModule module = getModule();
+        AirshipTitaniumModule module = getModule();
         if (module != null) {
             module.fireEvent(EVENT_PUSH_RECEIVED, createPushEvent(message, notificationId));
         }
@@ -190,7 +190,7 @@ public class UrbanAirshipModule extends KrollModule {
     }
 
     public static void onChannelUpdated(String channelId) {
-        UrbanAirshipModule module = getModule();
+        AirshipTitaniumModule module = getModule();
         if (module != null) {
             HashMap<String, String> event = new HashMap<>();
             event.put("channelId", channelId);
@@ -200,7 +200,7 @@ public class UrbanAirshipModule extends KrollModule {
 
     public static void deepLinkReceived(String dl) {
       deepLink = dl;
-    	UrbanAirshipModule module = getModule();
+    	AirshipTitaniumModule module = getModule();
         if (module != null) {
             HashMap<String, String> event = new HashMap<String, String>();
             event.put("deepLink", dl);
@@ -208,8 +208,8 @@ public class UrbanAirshipModule extends KrollModule {
         }
     }
 
-    private static UrbanAirshipModule getModule() {
-        return (UrbanAirshipModule)TiApplication.getInstance().getModuleByName(MODULE_NAME);
+    private static AirshipTitaniumModule getModule() {
+        return (AirshipTitaniumModule)TiApplication.getInstance().getModuleByName(MODULE_NAME);
     }
 
     private static HashMap<String, Object> createPushEvent(PushMessage message, Integer notificationId) {

--- a/android/src/ti/airship/ChannelTagEditorProxy.java
+++ b/android/src/ti/airship/ChannelTagEditorProxy.java
@@ -1,0 +1,4 @@
+package ti.airship;
+
+public class ChannelTagEditorProxy {
+}

--- a/android/src/ti/airship/ChannelTagEditorProxy.java
+++ b/android/src/ti/airship/ChannelTagEditorProxy.java
@@ -1,4 +1,0 @@
-package ti.airship;
-
-public class ChannelTagEditorProxy {
-}

--- a/android/src/ti/airship/TiAutopilot.java
+++ b/android/src/ti/airship/TiAutopilot.java
@@ -114,8 +114,7 @@ public class TiAutopilot extends Autopilot {
                 .setProductionAppKey(properties.getString(PRODUCTION_KEY, ""))
                 .setProductionAppSecret(properties.getString(PRODUCTION_SECRET, ""))
                 .setInProduction(properties.getBool(IN_PRODUCTION, false))
-                .setFcmSenderId(properties.getString(GCM_SENDER, null))
-                .setLogLevel(android.util.Log.VERBOSE);
+                .setFcmSenderId(properties.getString(GCM_SENDER, null));
 
         // Accent color
         String accentColor = properties.getString(NOTIFICATION_ACCENT_COLOR, null);

--- a/android/src/ti/airship/TiAutopilot.java
+++ b/android/src/ti/airship/TiAutopilot.java
@@ -1,6 +1,6 @@
 /* Copyright Airship and Contributors */
 
-package com.urbanairship.ti;
+package ti.airship;
 
 import android.content.Context;
 import android.graphics.Color;
@@ -16,6 +16,7 @@ import com.urbanairship.push.NotificationInfo;
 import com.urbanairship.push.NotificationListener;
 import com.urbanairship.util.UAStringUtil;
 
+import org.apache.log4j.lf5.LogLevel;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiProperties;
@@ -38,14 +39,14 @@ public class TiAutopilot extends Autopilot {
         Log.i(TAG, "Airship ready");
 
         airship.setDeepLinkListener(deepLink -> {
-            UrbanAirshipModule.deepLinkReceived(deepLink);
+            AirshipTitaniumModule.deepLinkReceived(deepLink);
             return true;
         });
 
         airship.getPushManager().addPushListener((message, notificationPosted) -> {
             Log.i(TAG, "Received push. Alert: " + message.getAlert());
             if (!notificationPosted) {
-                UrbanAirshipModule.onPushReceived(message, null);
+                AirshipTitaniumModule.onPushReceived(message, null);
             }
         });
 
@@ -53,27 +54,27 @@ public class TiAutopilot extends Autopilot {
             @Override
             public void onNotificationPosted(@NonNull NotificationInfo notificationInfo) {
                 Log.i(TAG, "Notification posted. Alert: " + notificationInfo.getMessage().getAlert());
-                UrbanAirshipModule.onPushReceived(notificationInfo.getMessage(), notificationInfo.getNotificationId());
+                AirshipTitaniumModule.onPushReceived(notificationInfo.getMessage(), notificationInfo.getNotificationId());
             }
 
             @Override
             public boolean onNotificationOpened(@NonNull NotificationInfo notificationInfo) {
                 Log.i(TAG, "Notification Opened. Alert: " + notificationInfo.getMessage().getAlert());
-                UrbanAirshipModule.onNotificationOpened(notificationInfo.getMessage(), notificationInfo.getNotificationId());
+                AirshipTitaniumModule.onNotificationOpened(notificationInfo.getMessage(), notificationInfo.getNotificationId());
                 return false;
             }
 
             @Override
             public boolean onNotificationForegroundAction(@NonNull NotificationInfo notificationInfo, @NonNull NotificationActionButtonInfo actionButtonInfo) {
                 Log.i(TAG, "User clicked notification button. Button ID: " + actionButtonInfo.getButtonId() + " Alert: " + notificationInfo.getMessage().getAlert());
-                UrbanAirshipModule.onNotificationOpened(notificationInfo.getMessage(), notificationInfo.getNotificationId());
+                AirshipTitaniumModule.onNotificationOpened(notificationInfo.getMessage(), notificationInfo.getNotificationId());
                 return false;
             }
 
             @Override
             public void onNotificationBackgroundAction(@NonNull NotificationInfo notificationInfo, @NonNull NotificationActionButtonInfo actionButtonInfo) {
                 Log.i(TAG, "User clicked notification button. Button ID: " + actionButtonInfo.getButtonId() + " Alert: " + notificationInfo.getMessage().getAlert());
-                UrbanAirshipModule.onNotificationOpened(notificationInfo.getMessage(), notificationInfo.getNotificationId());
+                AirshipTitaniumModule.onNotificationOpened(notificationInfo.getMessage(), notificationInfo.getNotificationId());
             }
 
             @Override
@@ -86,13 +87,13 @@ public class TiAutopilot extends Autopilot {
             @Override
             public void onChannelCreated(@NonNull String channelId) {
                 Log.i(TAG, "Channel created. Channel ID:" + channelId + ".");
-                UrbanAirshipModule.onChannelUpdated(channelId);
+                AirshipTitaniumModule.onChannelUpdated(channelId);
             }
 
             @Override
             public void onChannelUpdated(@NonNull String channelId) {
                 Log.i(TAG, "Channel updated. Channel ID:" + channelId + ".");
-                UrbanAirshipModule.onChannelUpdated(channelId);
+                AirshipTitaniumModule.onChannelUpdated(channelId);
             }
         });
 
@@ -113,7 +114,8 @@ public class TiAutopilot extends Autopilot {
                 .setProductionAppKey(properties.getString(PRODUCTION_KEY, ""))
                 .setProductionAppSecret(properties.getString(PRODUCTION_SECRET, ""))
                 .setInProduction(properties.getBool(IN_PRODUCTION, false))
-                .setFcmSenderId(properties.getString(GCM_SENDER, null));
+                .setFcmSenderId(properties.getString(GCM_SENDER, null))
+                .setLogLevel(android.util.Log.VERBOSE);
 
         // Accent color
         String accentColor = properties.getString(NOTIFICATION_ACCENT_COLOR, null);

--- a/android/src/ti/airship/Utils.java
+++ b/android/src/ti/airship/Utils.java
@@ -7,7 +7,9 @@ public abstract class Utils {
     public static Set<String> convertToStringSet(Object[] values) {
         HashSet<String> set = new HashSet<String>();
         for (Object value : values) {
-            set.add(String.valueOf(value));
+            if (value instanceof String) {
+                set.add((String) value);
+            }
         }
         return set;
     }

--- a/android/src/ti/airship/Utils.java
+++ b/android/src/ti/airship/Utils.java
@@ -1,0 +1,14 @@
+package ti.airship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class Utils {
+    public static Set<String> convertToStringSet(Object[] values) {
+        HashSet<String> set = new HashSet<String>();
+        for (Object value : values) {
+            set.add(String.valueOf(value));
+        }
+        return set;
+    }
+}

--- a/android/src/ti/airship/tags/ChannelTagGroupsEditorProxy.java
+++ b/android/src/ti/airship/tags/ChannelTagGroupsEditorProxy.java
@@ -1,0 +1,37 @@
+package ti.airship.tags;
+
+import com.urbanairship.UAirship;
+import com.urbanairship.channel.TagEditor;
+import com.urbanairship.channel.TagGroupsEditor;
+
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+
+import ti.airship.AirshipTitaniumModule;
+import ti.airship.Utils;
+
+@Kroll.proxy(creatableInModule = AirshipTitaniumModule.class)
+public class ChannelTagGroupsEditorProxy extends KrollProxy {
+
+    private final TagGroupsEditor editor = UAirship.shared().getChannel().editTagGroups();
+
+    @Kroll.method
+    public void removeTags(String group, Object[] args) {
+        editor.removeTags(group, Utils.convertToStringSet(args));
+    }
+
+    @Kroll.method
+    public void addTags(String group, Object[] tags) {
+        editor.addTags(group, Utils.convertToStringSet(tags));
+    }
+
+    @Kroll.method
+    public void setTags(String group, Object[] tags) {
+        editor.setTags(group, Utils.convertToStringSet(tags));
+    }
+
+    @Kroll.method
+    public void applyTags() {
+        editor.apply();
+    }
+}

--- a/android/src/ti/airship/tags/ChannelTagGroupsEditorProxy.java
+++ b/android/src/ti/airship/tags/ChannelTagGroupsEditorProxy.java
@@ -16,8 +16,8 @@ public class ChannelTagGroupsEditorProxy extends KrollProxy {
     private final TagGroupsEditor editor = UAirship.shared().getChannel().editTagGroups();
 
     @Kroll.method
-    public void removeTags(String group, Object[] args) {
-        editor.removeTags(group, Utils.convertToStringSet(args));
+    public void removeTags(String group, Object[] tags) {
+        editor.removeTags(group, Utils.convertToStringSet(tags));
     }
 
     @Kroll.method

--- a/android/src/ti/airship/tags/ChannelTagsEditorProxy.java
+++ b/android/src/ti/airship/tags/ChannelTagsEditorProxy.java
@@ -1,0 +1,36 @@
+package ti.airship.tags;
+
+import com.urbanairship.UAirship;
+import com.urbanairship.channel.TagEditor;
+
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+
+import ti.airship.AirshipTitaniumModule;
+import ti.airship.Utils;
+
+@Kroll.proxy(creatableInModule = AirshipTitaniumModule.class)
+public class ChannelTagsEditorProxy extends KrollProxy {
+
+    private final TagEditor editor = UAirship.shared().getChannel().editTags();
+
+    @Kroll.method
+    public void removeTags(Object[] tags) {
+        editor.removeTags(Utils.convertToStringSet(tags));
+    }
+
+    @Kroll.method
+    public void addTags(Object[] tags) {
+        editor.addTags(Utils.convertToStringSet(tags));
+    }
+
+    @Kroll.method
+    public void clearTags() {
+        editor.clear();
+    }
+
+    @Kroll.method
+    public void applyTags() {
+        editor.apply();
+    }
+}

--- a/android/src/ti/airship/tags/NamedUserTagGroupsEditorProxy.java
+++ b/android/src/ti/airship/tags/NamedUserTagGroupsEditorProxy.java
@@ -15,8 +15,8 @@ public class NamedUserTagGroupsEditorProxy extends KrollProxy {
     private final TagGroupsEditor editor = UAirship.shared().getNamedUser().editTagGroups();
 
     @Kroll.method
-    public void removeTags(String group, Object[] args) {
-        editor.removeTags(group, Utils.convertToStringSet(args));
+    public void removeTags(String group, Object[] tags) {
+        editor.removeTags(group, Utils.convertToStringSet(tags));
     }
 
     @Kroll.method

--- a/android/src/ti/airship/tags/NamedUserTagGroupsEditorProxy.java
+++ b/android/src/ti/airship/tags/NamedUserTagGroupsEditorProxy.java
@@ -1,0 +1,36 @@
+package ti.airship.tags;
+
+import com.urbanairship.UAirship;
+import com.urbanairship.channel.TagGroupsEditor;
+
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+
+import ti.airship.AirshipTitaniumModule;
+import ti.airship.Utils;
+
+@Kroll.proxy(creatableInModule = AirshipTitaniumModule.class)
+public class NamedUserTagGroupsEditorProxy extends KrollProxy {
+
+    private final TagGroupsEditor editor = UAirship.shared().getNamedUser().editTagGroups();
+
+    @Kroll.method
+    public void removeTags(String group, Object[] args) {
+        editor.removeTags(group, Utils.convertToStringSet(args));
+    }
+
+    @Kroll.method
+    public void addTags(String group, Object[] tags) {
+        editor.addTags(group, Utils.convertToStringSet(tags));
+    }
+
+    @Kroll.method
+    public void setTags(String group, Object[] tags) {
+        editor.setTags(group, Utils.convertToStringSet(tags));
+    }
+
+    @Kroll.method
+    public void applyTags() {
+        editor.apply();
+    }
+}

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -9,7 +9,7 @@
             <application>
  	            <!-- TiAutopilot -->
  	            <meta-data android:name="com.urbanairship.autopilot"
- 	            	android:value="com.urbanairship.ti.TiAutopilot" />
+ 	            	android:value="ti.airship.TiAutopilot" />
             </application>
         </manifest>
     </android>

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -83,7 +83,7 @@ Sets the namedUser for the device.
 
 ## Methods
 
-#### channelTagEditor
+#### createChannelTagsEditor
 
 The tag editor allows adding and removing tags on the channel.
 
@@ -91,7 +91,7 @@ The tag editor allows adding and removing tags on the channel.
     var editor = Airship.createChannelTagsEditor()
     editor.clearTags()
     editor.addTags("neat", "rad")
-    editor.removeTag("cool")
+    editor.removeTags("cool")
     editor.applyTags()
 ```
 
@@ -102,7 +102,7 @@ The tag editor allows editing channel tag groups.
 ```
     var editor = Airship.createChannelTagGroupsEditor()
     editor.addTags("group", "neat", "rad")
-    editor.removeTag("group", "cool")
+    editor.removeTags("group", "cool")
     editor.setTags("another group", "awesome")
     editor.applyTags()
 ```

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -64,22 +64,60 @@ notifications the first time will prompt the user to enable notifications.
 Sets or gets the channel tags. Tags can be used to segment the audience.
 
 ```
-    Airship.tags = ["test", "titanium"];
+    Airship.tags = ["test", "titanium"]
 
     Airship.tags.forEach(function(tag) {
-        Ti.API.info("Tag: " + tag);
+        Ti.API.info("Tag: " + tag)
     });
 ```
+
+
 
 #### namedUser
 
 Sets the namedUser for the device.
 
 ```
-    Airship.namedUser = "totes mcgoats";
+    Airship.namedUser = "totes mcgoats"
 ```
 
 ## Methods
+
+#### channelTagEditor
+
+The tag editor allows adding and removing tags on the channel.
+
+```
+    var editor = Airship.createChannelTagsEditor()
+    editor.clearTags()
+    editor.addTags("neat", "rad")
+    editor.removeTag("cool")
+    editor.applyTags()
+```
+
+#### createChannelTagGroupEditor
+
+The tag editor allows editing channel tag groups.
+
+```
+    var editor = Airship.createChannelTagGroupsEditor()
+    editor.addTags("group", "neat", "rad")
+    editor.removeTag("group", "cool")
+    editor.setTags("another group", "awesome")
+    editor.applyTags()
+```
+
+#### createNamedUserTagGroupEditor
+
+The tag editor allows editing named user tag groups.
+
+```
+    var editor = Airship.createNamedUserTagGroupsEditor()
+    editor.addTags("group", "neat", "rad")
+    editor.removeTag("group", "cool")
+    editor.setTags("another group", "awesome")
+    editor.applyTags()
+```
 
 ### getLaunchNotification([clear])
 
@@ -102,7 +140,7 @@ Gets the deep link that launched the app.
 `clear` is used to prevent getDeepLink from returning the deepLink again.
 
 ```
-    Ti.API.info("Deep link: " + Airship.getDeepLink(false));
+    Ti.API.info("Deep link: " + Airship.getDeepLink(false))
 ```
 
 ### displayMessageCenter()
@@ -110,7 +148,7 @@ Gets the deep link that launched the app.
 Displays the message center.
 
 ```
-    Airship.displayMessageCenter();
+    Airship.displayMessageCenter()
 ```
 
 ### associateIdentifier(key, identifier)
@@ -122,7 +160,7 @@ It is a set operation.
  - identifier: The value of the identifier as a string, or `null` to remove the identifier.
 
 ```
-    Airship.associateIdentifier("customKey", "customIdentifier");
+    Airship.associateIdentifier("customKey", "customIdentifier")
 ```
 
 ### addCustomEvent(eventPayload)
@@ -145,8 +183,8 @@ Adds a custom event.
         someLong: 1234567890,
         someArray: ["tangerine", "pineapple", "kiwi"]
       }
-    };
+    }
 
-    var customEventPayload = JSON.stringify(customEvent);
-    Airship.addCustomEvent(customEventPayload);
+    var customEventPayload = JSON.stringify(customEvent)
+    Airship.addCustomEvent(customEventPayload)
 ```

--- a/ios/AirshipTitanium.xcodeproj/project.pbxproj
+++ b/ios/AirshipTitanium.xcodeproj/project.pbxproj
@@ -30,6 +30,16 @@
 		3CD5DEC1247DEE0F0010AD85 /* TiAirshipDeeplink.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CD5DEBF247DEE0F0010AD85 /* TiAirshipDeeplink.m */; };
 		3CD5DEC4247DF23F0010AD85 /* TiAirshipAutopilot.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CD5DEC2247DF23F0010AD85 /* TiAirshipAutopilot.h */; };
 		3CD5DEC5247DF23F0010AD85 /* TiAirshipAutopilot.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CD5DEC3247DF23F0010AD85 /* TiAirshipAutopilot.m */; };
+		6E2FA9BE24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2FA9BC24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.h */; };
+		6E2FA9BF24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2FA9BD24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.m */; };
+		6E2FA9C424859981000B35E1 /* TiAirshipTagGroupOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2FA9C024859981000B35E1 /* TiAirshipTagGroupOperation.m */; };
+		6E2FA9C524859981000B35E1 /* TiAirshipChannelTagsEditorProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2FA9C124859981000B35E1 /* TiAirshipChannelTagsEditorProxy.h */; };
+		6E2FA9C624859981000B35E1 /* TiAirshipTagGroupOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2FA9C224859981000B35E1 /* TiAirshipTagGroupOperation.h */; };
+		6E2FA9C724859981000B35E1 /* TiAirshipChannelTagsEditorProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2FA9C324859981000B35E1 /* TiAirshipChannelTagsEditorProxy.m */; };
+		6E2FA9CA24859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2FA9C824859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.h */; };
+		6E2FA9CB24859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2FA9C924859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.m */; };
+		6E2FA9CE2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2FA9CC2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.h */; };
+		6E2FA9CF2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2FA9CD2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.m */; };
 		AA747D9F0F9514B9006C5449 /* TiAirship_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = AA747D9E0F9514B9006C5449 /* TiAirship_Prefix.pch */; };
 		AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
 /* End PBXBuildFile section */
@@ -54,6 +64,16 @@
 		3CD5DEBF247DEE0F0010AD85 /* TiAirshipDeeplink.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiAirshipDeeplink.m; path = Classes/TiAirshipDeeplink.m; sourceTree = "<group>"; };
 		3CD5DEC2247DF23F0010AD85 /* TiAirshipAutopilot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TiAirshipAutopilot.h; path = Classes/TiAirshipAutopilot.h; sourceTree = "<group>"; };
 		3CD5DEC3247DF23F0010AD85 /* TiAirshipAutopilot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiAirshipAutopilot.m; path = Classes/TiAirshipAutopilot.m; sourceTree = "<group>"; };
+		6E2FA9BC24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TiAirshipChannelTagGroupsEditorProxy.h; path = Classes/TiAirshipChannelTagGroupsEditorProxy.h; sourceTree = "<group>"; };
+		6E2FA9BD24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiAirshipChannelTagGroupsEditorProxy.m; path = Classes/TiAirshipChannelTagGroupsEditorProxy.m; sourceTree = "<group>"; };
+		6E2FA9C024859981000B35E1 /* TiAirshipTagGroupOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TiAirshipTagGroupOperation.m; path = Classes/TiAirshipTagGroupOperation.m; sourceTree = "<group>"; };
+		6E2FA9C124859981000B35E1 /* TiAirshipChannelTagsEditorProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TiAirshipChannelTagsEditorProxy.h; path = Classes/TiAirshipChannelTagsEditorProxy.h; sourceTree = "<group>"; };
+		6E2FA9C224859981000B35E1 /* TiAirshipTagGroupOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TiAirshipTagGroupOperation.h; path = Classes/TiAirshipTagGroupOperation.h; sourceTree = "<group>"; };
+		6E2FA9C324859981000B35E1 /* TiAirshipChannelTagsEditorProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TiAirshipChannelTagsEditorProxy.m; path = Classes/TiAirshipChannelTagsEditorProxy.m; sourceTree = "<group>"; };
+		6E2FA9C824859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TiAirshipNamedUserTagGroupsEditorProxy.h; path = Classes/TiAirshipNamedUserTagGroupsEditorProxy.h; sourceTree = "<group>"; };
+		6E2FA9C924859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiAirshipNamedUserTagGroupsEditorProxy.m; path = Classes/TiAirshipNamedUserTagGroupsEditorProxy.m; sourceTree = "<group>"; };
+		6E2FA9CC2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "TiProxy+TiAirshipTagGroupOperationAddition.h"; path = "Classes/TiProxy+TiAirshipTagGroupOperationAddition.h"; sourceTree = "<group>"; };
+		6E2FA9CD2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "TiProxy+TiAirshipTagGroupOperationAddition.m"; path = "Classes/TiProxy+TiAirshipTagGroupOperationAddition.m"; sourceTree = "<group>"; };
 		AA747D9E0F9514B9006C5449 /* TiAirship_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiAirship_Prefix.pch; sourceTree = SOURCE_ROOT; };
 		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D2AAC07E0554694100DB518D /* libti.airship.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libti.airship.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -101,6 +121,7 @@
 		08FB77AEFE84172EC02AAC07 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				6E2FA9B7248590CD000B35E1 /* Tags */,
 				24DE9E0F11C5FE74003F90F6 /* TiAirshipModuleAssets.h */,
 				24DE9E1011C5FE74003F90F6 /* TiAirshipModuleAssets.m */,
 				24DD6CF71134B3F500162E58 /* TiAirshipModule.h */,
@@ -122,6 +143,23 @@
 			name = "Other Sources";
 			sourceTree = "<group>";
 		};
+		6E2FA9B7248590CD000B35E1 /* Tags */ = {
+			isa = PBXGroup;
+			children = (
+				6E2FA9CC2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.h */,
+				6E2FA9CD2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.m */,
+				6E2FA9C224859981000B35E1 /* TiAirshipTagGroupOperation.h */,
+				6E2FA9C024859981000B35E1 /* TiAirshipTagGroupOperation.m */,
+				6E2FA9C124859981000B35E1 /* TiAirshipChannelTagsEditorProxy.h */,
+				6E2FA9C324859981000B35E1 /* TiAirshipChannelTagsEditorProxy.m */,
+				6E2FA9BC24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.h */,
+				6E2FA9BD24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.m */,
+				6E2FA9C824859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.h */,
+				6E2FA9C924859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.m */,
+			);
+			name = Tags;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -129,11 +167,16 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E2FA9CE2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.h in Headers */,
 				3CD5DEC4247DF23F0010AD85 /* TiAirshipAutopilot.h in Headers */,
 				AA747D9F0F9514B9006C5449 /* TiAirship_Prefix.pch in Headers */,
 				24DD6CF91134B3F500162E58 /* TiAirshipModule.h in Headers */,
 				3CD5DEC0247DEE0F0010AD85 /* TiAirshipDeeplink.h in Headers */,
+				6E2FA9CA24859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.h in Headers */,
+				6E2FA9C624859981000B35E1 /* TiAirshipTagGroupOperation.h in Headers */,
 				24DE9E1111C5FE74003F90F6 /* TiAirshipModuleAssets.h in Headers */,
+				6E2FA9C524859981000B35E1 /* TiAirshipChannelTagsEditorProxy.h in Headers */,
+				6E2FA9BE24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,9 +251,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				24DD6CFA1134B3F500162E58 /* TiAirshipModule.m in Sources */,
+				6E2FA9CB24859AE8000B35E1 /* TiAirshipNamedUserTagGroupsEditorProxy.m in Sources */,
+				6E2FA9C424859981000B35E1 /* TiAirshipTagGroupOperation.m in Sources */,
+				6E2FA9BF24859963000B35E1 /* TiAirshipChannelTagGroupsEditorProxy.m in Sources */,
+				6E2FA9CF2485B44E000B35E1 /* TiProxy+TiAirshipTagGroupOperationAddition.m in Sources */,
 				3CD5DEC5247DF23F0010AD85 /* TiAirshipAutopilot.m in Sources */,
 				24DE9E1211C5FE74003F90F6 /* TiAirshipModuleAssets.m in Sources */,
 				3CD5DEC1247DEE0F0010AD85 /* TiAirshipDeeplink.m in Sources */,
+				6E2FA9C724859981000B35E1 /* TiAirshipChannelTagsEditorProxy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Classes/TiAirshipChannelTagGroupsEditorProxy.h
+++ b/ios/Classes/TiAirshipChannelTagGroupsEditorProxy.h
@@ -1,10 +1,11 @@
 /* Copyright Airship and Contributors */
 
 #import <Foundation/Foundation.h>
+#import "TiProxy.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface TiAirshipAutopilot : NSObject
+@interface TiAirshipChannelTagGroupsEditorProxy : TiProxy
 
 @end
 

--- a/ios/Classes/TiAirshipChannelTagGroupsEditorProxy.m
+++ b/ios/Classes/TiAirshipChannelTagGroupsEditorProxy.m
@@ -12,8 +12,7 @@
 
 @implementation TiAirshipChannelTagGroupsEditorProxy
 
-- (instancetype)init
-{
+- (instancetype)init {
     self = [super init];
     if (self) {
         self.operations = [NSMutableArray array];

--- a/ios/Classes/TiAirshipChannelTagGroupsEditorProxy.m
+++ b/ios/Classes/TiAirshipChannelTagGroupsEditorProxy.m
@@ -1,0 +1,59 @@
+/* Copyright Airship and Contributors */
+
+#import "TiAirshipChannelTagGroupsEditorProxy.h"
+#import "TiAirshipTagGroupOperation.h"
+#import "TiProxy+TiAirshipTagGroupOperationAddition.h"
+
+@import AirshipCore;
+
+@interface TiAirshipChannelTagGroupsEditorProxy ()
+@property (nonatomic, strong) NSMutableArray<TiAirshipTagGroupOperation *> *operations;
+@end
+
+@implementation TiAirshipChannelTagGroupsEditorProxy
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.operations = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)addTags:(id)args {
+    [self.operations addObject:[self operationFromArgs:args
+                                                  type:TiAirshipTagGroupOperationTypeAdd]];
+}
+
+- (void)removeTags:(id)args {
+    [self.operations addObject:[self operationFromArgs:args
+                                                  type:TiAirshipTagGroupOperationTypeRemove]];
+}
+
+- (void)setTags:(id)args {
+    [self.operations addObject:[self operationFromArgs:args
+                                                  type:TiAirshipTagGroupOperationTypeSet]];
+}
+
+- (void)applyTags:(id)args {
+    UAChannel *channel = [UAirship channel];
+
+    for (TiAirshipTagGroupOperation *operation in self.operations) {
+        switch (operation.type) {
+            case TiAirshipTagGroupOperationTypeSet:
+                [channel setTags:operation.tags group:operation.group];
+                break;
+            case TiAirshipTagGroupOperationTypeAdd:
+                [channel addTags:operation.tags group:operation.group];
+                break;
+            case TiAirshipTagGroupOperationTypeRemove:
+                [channel removeTags:operation.tags group:operation.group];
+                break;
+        }
+    }
+
+    [channel updateRegistration];
+}
+
+@end

--- a/ios/Classes/TiAirshipChannelTagsEditorProxy.h
+++ b/ios/Classes/TiAirshipChannelTagsEditorProxy.h
@@ -1,11 +1,11 @@
 /* Copyright Airship and Contributors */
 
 #import <Foundation/Foundation.h>
+#import "TiProxy.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface TiAirshipAutopilot : NSObject
-
+@interface TiAirshipChannelTagsEditorProxy : TiProxy
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Classes/TiAirshipChannelTagsEditorProxy.m
+++ b/ios/Classes/TiAirshipChannelTagsEditorProxy.m
@@ -7,7 +7,7 @@
 @interface TiAirshipChannelTagsEditorProxy ()
 @property (nonatomic, strong) NSMutableSet<NSString *> *tagsToAdd;
 @property (nonatomic, strong) NSMutableSet<NSString *> *tagsToRemove;
-@property (nonatomic) bool clear;
+@property (nonatomic) BOOL clear;
 @end
 
 @implementation TiAirshipChannelTagsEditorProxy

--- a/ios/Classes/TiAirshipChannelTagsEditorProxy.m
+++ b/ios/Classes/TiAirshipChannelTagsEditorProxy.m
@@ -12,8 +12,7 @@
 
 @implementation TiAirshipChannelTagsEditorProxy
 
-- (instancetype)init
-{
+- (instancetype)init {
     self = [super init];
     if (self) {
         self.tagsToAdd = [NSMutableSet set];
@@ -29,17 +28,13 @@
 - (void)addTags:(id)args {
     ENSURE_ARRAY(args);
     [self.tagsToAdd addObjectsFromArray:args];
-    for (id tag in args) {
-        [self.tagsToRemove removeObject:tag];
-    }
+    [self.tagsToRemove removeObjectsInArray:args];
 }
 
 - (void)removeTags:(id)args {
     ENSURE_ARRAY(args);
     [self.tagsToRemove addObjectsFromArray:args];
-    for (id tag in args) {
-        [self.tagsToAdd removeObject:tag];
-    }
+    [self.tagsToAdd removeObjectsInArray:args];
 }
 
 - (void)applyTags:(id)args {
@@ -47,7 +42,6 @@
     if (self.clear) {
         channel.tags = @[];
     }
-
 
     [channel addTags:[self.tagsToAdd allObjects]];
     [channel removeTags:[self.tagsToRemove allObjects]];

--- a/ios/Classes/TiAirshipChannelTagsEditorProxy.m
+++ b/ios/Classes/TiAirshipChannelTagsEditorProxy.m
@@ -12,7 +12,6 @@
 
 @implementation TiAirshipChannelTagsEditorProxy
 
-
 - (instancetype)init
 {
     self = [super init];
@@ -54,6 +53,5 @@
     [channel removeTags:[self.tagsToRemove allObjects]];
     [channel updateRegistration];
 }
-
 
 @end

--- a/ios/Classes/TiAirshipChannelTagsEditorProxy.m
+++ b/ios/Classes/TiAirshipChannelTagsEditorProxy.m
@@ -28,13 +28,13 @@
 - (void)addTags:(id)args {
     ENSURE_ARRAY(args);
     [self.tagsToAdd addObjectsFromArray:args];
-    [self.tagsToRemove removeObjectsInArray:args];
+    [self.tagsToRemove minusSet:[NSSet setWithArray:args]];
 }
 
 - (void)removeTags:(id)args {
     ENSURE_ARRAY(args);
     [self.tagsToRemove addObjectsFromArray:args];
-    [self.tagsToAdd removeObjectsInArray:args];
+    [self.tagsToAdd minusSet:[NSSet setWithArray:args]];
 }
 
 - (void)applyTags:(id)args {

--- a/ios/Classes/TiAirshipChannelTagsEditorProxy.m
+++ b/ios/Classes/TiAirshipChannelTagsEditorProxy.m
@@ -1,0 +1,59 @@
+/* Copyright Airship and Contributors */
+
+#import "TiAirshipChannelTagsEditorProxy.h"
+#import "TiUtils.h"
+@import AirshipCore;
+
+@interface TiAirshipChannelTagsEditorProxy ()
+@property (nonatomic, strong) NSMutableSet<NSString *> *tagsToAdd;
+@property (nonatomic, strong) NSMutableSet<NSString *> *tagsToRemove;
+@property (nonatomic) bool clear;
+@end
+
+@implementation TiAirshipChannelTagsEditorProxy
+
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.tagsToAdd = [NSMutableSet set];
+        self.tagsToRemove = [NSMutableSet set];
+    }
+    return self;
+}
+
+- (void)clearTags {
+    self.clear = YES;
+}
+
+- (void)addTags:(id)args {
+    ENSURE_ARRAY(args);
+    [self.tagsToAdd addObjectsFromArray:args];
+    for (id tag in args) {
+        [self.tagsToRemove removeObject:tag];
+    }
+}
+
+- (void)removeTags:(id)args {
+    ENSURE_ARRAY(args);
+    [self.tagsToRemove addObjectsFromArray:args];
+    for (id tag in args) {
+        [self.tagsToAdd removeObject:tag];
+    }
+}
+
+- (void)applyTags:(id)args {
+    UAChannel *channel = [UAirship channel];
+    if (self.clear) {
+        channel.tags = @[];
+    }
+
+
+    [channel addTags:[self.tagsToAdd allObjects]];
+    [channel removeTags:[self.tagsToRemove allObjects]];
+    [channel updateRegistration];
+}
+
+
+@end

--- a/ios/Classes/TiAirshipNamedUserTagGroupsEditorProxy.h
+++ b/ios/Classes/TiAirshipNamedUserTagGroupsEditorProxy.h
@@ -1,10 +1,11 @@
 /* Copyright Airship and Contributors */
 
 #import <Foundation/Foundation.h>
+#import "TiProxy.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface TiAirshipAutopilot : NSObject
+@interface TiAirshipNamedUserTagGroupsEditorProxy : TiProxy
 
 @end
 

--- a/ios/Classes/TiAirshipNamedUserTagGroupsEditorProxy.m
+++ b/ios/Classes/TiAirshipNamedUserTagGroupsEditorProxy.m
@@ -12,8 +12,7 @@
 
 @implementation TiAirshipNamedUserTagGroupsEditorProxy
 
-- (instancetype)init
-{
+- (instancetype)init {
     self = [super init];
     if (self) {
         self.operations = [NSMutableArray array];

--- a/ios/Classes/TiAirshipNamedUserTagGroupsEditorProxy.m
+++ b/ios/Classes/TiAirshipNamedUserTagGroupsEditorProxy.m
@@ -1,0 +1,59 @@
+/* Copyright Airship and Contributors */
+
+#import "TiAirshipNamedUserTagGroupsEditorProxy.h"
+#import "TiAirshipTagGroupOperation.h"
+#import "TiProxy+TiAirshipTagGroupOperationAddition.h"
+
+@import AirshipCore;
+
+@interface TiAirshipNamedUserTagGroupsEditorProxy ()
+@property (nonatomic, strong) NSMutableArray<TiAirshipTagGroupOperation *> *operations;
+@end
+
+@implementation TiAirshipNamedUserTagGroupsEditorProxy
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.operations = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)addTags:(id)args {
+    [self.operations addObject:[self operationFromArgs:args
+                                                  type:TiAirshipTagGroupOperationTypeAdd]];
+}
+
+- (void)removeTags:(id)args {
+    [self.operations addObject:[self operationFromArgs:args
+                                                  type:TiAirshipTagGroupOperationTypeRemove]];
+}
+
+- (void)setTags:(id)args {
+    [self.operations addObject:[self operationFromArgs:args
+                                                  type:TiAirshipTagGroupOperationTypeSet]];
+}
+
+- (void)applyTags:(id)args {
+    UANamedUser *namedUser = [UAirship namedUser];
+
+    for (TiAirshipTagGroupOperation *operation in self.operations) {
+        switch (operation.type) {
+            case TiAirshipTagGroupOperationTypeSet:
+                [namedUser setTags:operation.tags group:operation.group];
+                break;
+            case TiAirshipTagGroupOperationTypeAdd:
+                [namedUser addTags:operation.tags group:operation.group];
+                break;
+            case TiAirshipTagGroupOperationTypeRemove:
+                [namedUser removeTags:operation.tags group:operation.group];
+                break;
+        }
+    }
+
+    [namedUser updateTags];
+}
+
+@end

--- a/ios/Classes/TiAirshipTagGroupOperation.h
+++ b/ios/Classes/TiAirshipTagGroupOperation.h
@@ -1,0 +1,24 @@
+/* Copyright Airship and Contributors */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, TiAirshipTagGroupOperationType) {
+    TiAirshipTagGroupOperationTypeAdd,
+    TiAirshipTagGroupOperationTypeRemove,
+    TiAirshipTagGroupOperationTypeSet
+};
+
+@interface TiAirshipTagGroupOperation : NSObject
+
+@property (nonatomic, assign, readonly) TiAirshipTagGroupOperationType type;
+@property (nonatomic, copy, readonly) NSArray *tags;
+@property (nonatomic, copy, readonly) NSString *group;
+
++ (instancetype)operationForType:(TiAirshipTagGroupOperationType)type
+                            tags:(NSArray *)tags
+                           group:(NSString *)group;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Classes/TiAirshipTagGroupOperation.m
+++ b/ios/Classes/TiAirshipTagGroupOperation.m
@@ -12,8 +12,7 @@
 
 - (instancetype)initWithType:(TiAirshipTagGroupOperationType)type
                         tags:(NSArray *)tags
-                       group:(NSString *)group
-{
+                       group:(NSString *)group {
     self = [super init];
     if (self) {
         self.type = type;

--- a/ios/Classes/TiAirshipTagGroupOperation.m
+++ b/ios/Classes/TiAirshipTagGroupOperation.m
@@ -1,0 +1,32 @@
+/* Copyright Airship and Contributors */
+
+#import "TiAirshipTagGroupOperation.h"
+
+@interface TiAirshipTagGroupOperation ()
+@property (nonatomic, assign) TiAirshipTagGroupOperationType type;
+@property (nonatomic, copy) NSArray *tags;
+@property (nonatomic, copy) NSString *group;
+@end
+
+@implementation TiAirshipTagGroupOperation
+
+- (instancetype)initWithType:(TiAirshipTagGroupOperationType)type
+                        tags:(NSArray *)tags
+                       group:(NSString *)group
+{
+    self = [super init];
+    if (self) {
+        self.type = type;
+        self.tags = tags;
+        self.group = group;
+    }
+    return self;
+}
+
++ (instancetype)operationForType:(TiAirshipTagGroupOperationType)type
+                            tags:(NSArray *)tags
+                           group:(NSString *)group {
+    return [[self alloc] initWithType:type tags:tags group:group];
+}
+
+@end

--- a/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.h
+++ b/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.h
@@ -1,0 +1,20 @@
+//
+//  TiProxy+UAAdditions.h
+//  AirshipTitanium
+//
+//  Created by Ryan Lepinski on 6/1/20.
+//
+
+#import <Foundation/Foundation.h>
+#import "TiProxy.h"
+#import "TiAirshipTagGroupOperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TiProxy (TiAirshipTagGroupOperationAddition)
+
+- (TiAirshipTagGroupOperation *)operationFromArgs:(id)args
+                                             type:(TiAirshipTagGroupOperationType)type;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.h
+++ b/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.h
@@ -1,9 +1,4 @@
-//
-//  TiProxy+UAAdditions.h
-//  AirshipTitanium
-//
-//  Created by Ryan Lepinski on 6/1/20.
-//
+/* Copyright Airship and Contributors */
 
 #import <Foundation/Foundation.h>
 #import "TiProxy.h"

--- a/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.m
+++ b/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.m
@@ -1,9 +1,4 @@
-//
-//  TiProxy+UAAdditions.m
-//  AirshipTitanium
-//
-//  Created by Ryan Lepinski on 6/1/20.
-//
+/* Copyright Airship and Contributors */
 
 #import "TiProxy+TiAirshipTagGroupOperationAddition.h"
 #import "TiBase.h"
@@ -26,6 +21,5 @@
 
     return [TiAirshipTagGroupOperation operationForType:type tags:tags group:group];
 }
-
 
 @end

--- a/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.m
+++ b/ios/Classes/TiProxy+TiAirshipTagGroupOperationAddition.m
@@ -1,0 +1,31 @@
+//
+//  TiProxy+UAAdditions.m
+//  AirshipTitanium
+//
+//  Created by Ryan Lepinski on 6/1/20.
+//
+
+#import "TiProxy+TiAirshipTagGroupOperationAddition.h"
+#import "TiBase.h"
+
+@implementation TiProxy(TiAirshipTagGroupOperationAddition)
+
+- (TiAirshipTagGroupOperation *)operationFromArgs:(id)args
+                                             type:(TiAirshipTagGroupOperationType)type {
+
+    ENSURE_ARG_COUNT(args, 2);
+    ENSURE_ARRAY(args);
+    for (NSString *arg in args) {
+        ENSURE_STRING(arg);
+    }
+
+    NSArray *array = args;
+    NSString *group = array[0];
+    NSMutableArray *tags = [args mutableCopy];
+    [tags removeObjectAtIndex:0];
+
+    return [TiAirshipTagGroupOperation operationForType:type tags:tags group:group];
+}
+
+
+@end


### PR DESCRIPTION
Adds tag editors to the module for both tags and tag groups. I also cleaned up some namespacing issues in the Android module.

```
// Set Tags
var editor = Airship.createChannelTagsEditor()
editor.addTags("foo")
editor.addTags("rad", "neat", "woot")
editor.removeTags("rad")
editor.applyTags()

editor = Airship.createChannelTagGroupsEditor()
editor.addTags("addGroup", osname)
editor.addTags("addGroup", "neat", "woot")
editor.removeTags("removeGroup", "rad")
editor.setTags("setGroup", "rad")
editor.applyTags()

editor = Airship.createNamedUserTagGroupsEditor()
editor.addTags("addGroup", osname)
editor.addTags("addGroup", "neat", "woot")
editor.removeTags("removeGroup", "rad")
editor.setTags("setGroup", "rad")
editor.applyTags()
```
