### PR TITLE
Mobile 1662

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ clean:
 	rm -rf android/libs
 	rm -rf ios/build
 	rm -rf ios/dist
-	rm -rf ~/Library/Application Support/Titanium/modules/iphone/ti.airship/
+	rm -rf "${HOME}/Library/Application Support/Titanium/modules/iphone/ti.airship/"
 
 

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,6 @@ clean:
 	rm -rf android/libs
 	rm -rf ios/build
 	rm -rf ios/dist
+	rm -rf ~/Library/Application Support/Titanium/modules/iphone/ti.airship/
 
 

--- a/android/src/ti/airship/AirshipTitaniumModule.java
+++ b/android/src/ti/airship/AirshipTitaniumModule.java
@@ -6,6 +6,7 @@ import com.urbanairship.Autopilot;
 import com.urbanairship.UAirship;
 import com.urbanairship.actions.ActionRunRequest;
 import com.urbanairship.actions.AddCustomEventAction;
+import com.urbanairship.iam.InAppMessageManager;
 import com.urbanairship.json.JsonException;
 import com.urbanairship.json.JsonMap;
 import com.urbanairship.json.JsonValue;
@@ -91,6 +92,18 @@ public class AirshipTitaniumModule extends KrollModule {
     @Kroll.setProperty
     public void setUserNotificationsEnabled(boolean enabled) {
         UAirship.shared().getPushManager().setUserNotificationsEnabled(enabled);
+    }
+
+    @Kroll.method
+    @Kroll.getProperty
+    public boolean getIsInAppAutomationPaused() {
+        return InAppMessageManager.shared().isPaused();
+    }
+
+    @Kroll.method
+    @Kroll.setProperty
+    public void setIsInAppAutomationPaused(boolean paused) {
+        InAppMessageManager.shared().setPaused(paused);
     }
 
     @Kroll.method

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -6,7 +6,8 @@
 
 Listens for any channel updates. Event contains the following:
  - channelId: The channel ID of the app instance.
- - deviceToken: (iOS only) The device token.
+ - deviceToken: (deprecated, iOS only) The device token.
+ - pushToken: The push token.
 
 ```
     Airship.addEventListener(Airship.EVENT_CHANNEL_UPDATED, function(e) {
@@ -86,7 +87,7 @@ Enables or disables data collection. To require data be opted in before collecte
 data collection disables tags, attributes, analytics, named user, and push. To allow the user to still receive broadcast pushes, set `isPushTokenRegistrationEnabled` to true.
 
 ```
-    Airship.isDataCollectionEnabled = true;
+    Airship.isDataCollectionEnabled = true
 ```
 
 ### isPushTokenRegistrationEnabled
@@ -94,8 +95,17 @@ data collection disables tags, attributes, analytics, named user, and push. To a
 Enables or disables push token registration. This value defaults to the current value of `isDataCollectionEnabled`. Can be used to enable broadcast push and still have data collection disabled.
 
 ```
-    Airship.isPushTokenRegistrationEnabled = true;
+    Airship.isPushTokenRegistrationEnabled = true
 ```
+
+### isInAppAutomationPaused
+
+Pauses or resumes In-App messaging.
+
+```
+    Airship.isInAppAutomationPaused = true
+```
+
 
 ### isAutoBadgeEnabled (iOS only)
 

--- a/ios/Classes/TiAirshipEventEmitter.m
+++ b/ios/Classes/TiAirshipEventEmitter.m
@@ -9,10 +9,10 @@
 @property (nonatomic, weak) TiProxy *proxy;
 @property (nonatomic, strong) NSMutableDictionary *listeners;
 
-- (void)addListenersrForEvent:(NSString *)event
+- (void)addListenersForEvent:(NSString *)event
                         count:(NSUInteger)count;
 
-- (void)removeListenersrForEvent:(NSString *)event
+- (void)removeListenersForEvent:(NSString *)event
                            count:(NSUInteger)count;
 
 - (BOOL)fireEvent:(id<TiAirshipEvent>)event;

--- a/ios/Classes/TiAirshipModule.h
+++ b/ios/Classes/TiAirshipModule.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @import AirshipCore;
 @import AirshipMessageCenter;
+@import AirshipAutomation;
 
 @interface TiAirshipModule : TiModule
 

--- a/ios/Classes/TiAirshipModule.m
+++ b/ios/Classes/TiAirshipModule.m
@@ -109,6 +109,15 @@ NS_ASSUME_NONNULL_BEGIN
     [UAirship namedUser].identifier = args;
 }
 
+- (id)isInAppAutomationPaused {
+    return NUMBOOL([UAInAppMessageManager shared].isPaused);
+}
+
+- (void)setIsInAppAutomationPaused:(id)args {
+    ENSURE_SINGLE_ARG(args, NSNumber);
+    [UAInAppMessageManager shared].paused = [args boolValue];
+}
+
 - (void)associateIdentifier:(id)args {
     ENSURE_ARG_COUNT(args, 2);
     NSString *keyString = [TiUtils stringValue:[args objectAtIndex:0]];

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -12,6 +12,7 @@ echo "Updating carthage"
 carthage update
 
 echo "Copying frameworks"
+rm -rf "platform/Airship*.framework"
 cp -R "Carthage/Build/iOS/AirshipCore.framework" "platform/"
 cp -R "Carthage/Build/iOS/AirshipMessageCenter.framework" "platform/"
 

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -15,6 +15,7 @@ echo "Copying frameworks"
 rm -rf "platform/Airship*.framework"
 cp -R "Carthage/Build/iOS/AirshipCore.framework" "platform/"
 cp -R "Carthage/Build/iOS/AirshipMessageCenter.framework" "platform/"
+cp -R "Carthage/Build/iOS/AirshipAutomation.framework" "platform/"
 
 echo "Building iOS"
 npx appc run -p ios --build-only


### PR DESCRIPTION
Adds marcs fix in make/build file, cleans up some typos in an internal class from last PR, adds AirshipAutomation on iOS, and adds a property to pause IAA.

Tested on a device.