### PR TITLE
[MOBILE-1821] Release 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Airship Titanium Module
 
+## Version 7.1.0 - August 20, 2020
+Minor release bundling the following SDK updates:
+
+### iOS (Updated iOS SDK from 13.4.0 to 13.5.4)
+- Addresses [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) build warnings and Message Center Inbox UI issues. (13.5.4)
+- Fixes a crash with Accengage data migration. (13.5.3)
+- Improves iOS 14 support and fixes In-App Automation issues. (13.5.2)
+- Improves compatibility with Xcode 12, adding new messageCenterStyle properties to the default message center UI classes to avoid conflicting with UIKit changes in iOS 14 (13.5.1)
+- Adds support for application-defined locale overrides, and fixes issues in In-App Automation and the Actions Framework. (13.5.0)
+
+For more details, see the [iOS CHANGELOG](https://github.com/urbanairship/ios-library/blob/13.5.4/CHANGELOG.md).
+
+### Android (Updated Android SDK from 13.2.1 to 13.3.2)
+- Fixes In-App Automation version triggers to only fire on app updates instead of new installs. (13.3.2)
+- Fixes ADM registration exceptions that occur on first run and text alignment issues with In-App Automation. (13.3.1)
+- Allows overriding the locale used by Airship. (13.3.0)
+- Fixes In-App automation display intervals being ignored if the app is killed and HMS token registration on older Huawei devices. (13.2.2)
+
+For more details, see the [Android CHANGELOG](https://github.com/urbanairship/android-library/blob/13.3.2/CHANGELOG.md.
+
 ## Version 7.0.0 - July 8, 2020
 Major update to add significant functionality to the Titanium module. These updates take advantage of the latest iOS and Android SDKs APIs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For more details, see the [iOS CHANGELOG](https://github.com/urbanairship/ios-li
 - Allows overriding the locale used by Airship. (13.3.0)
 - Fixes In-App automation display intervals being ignored if the app is killed and HMS token registration on older Huawei devices. (13.2.2)
 
-For more details, see the [Android CHANGELOG](https://github.com/urbanairship/android-library/blob/13.3.2/CHANGELOG.md.
+For more details, see the [Android CHANGELOG](https://github.com/urbanairship/android-library/blob/13.3.2/CHANGELOG.md).
 
 ## Version 7.0.0 - July 8, 2020
 Major update to add significant functionality to the Titanium module. These updates take advantage of the latest iOS and Android SDKs APIs.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  def airshipVersion = "13.2.1"
+  def airshipVersion = "13.3.2"
 
   // ADM & FCM push providers
   implementation "com.urbanairship.android:urbanairship-fcm:$airshipVersion"

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 7.0.0
+version: 7.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Airship Titanium module

--- a/android/src/ti/airship/TiAirshipModuleVersion.java
+++ b/android/src/ti/airship/TiAirshipModuleVersion.java
@@ -1,6 +1,6 @@
 package ti.airship;
 
 public class TiAirshipModuleVersion {
-    static final String TI_AIRSHIP_MODULE_VERSION = "7.0.0";
+    static final String TI_AIRSHIP_MODULE_VERSION = "7.1.0";
 }
 

--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 13.4.0
+github "urbanairship/ios-library" == 13.5.4

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" "13.4.0"
+github "urbanairship/ios-library" "13.5.4"

--- a/ios/Classes/TiAirshipModuleVersion.m
+++ b/ios/Classes/TiAirshipModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "TiAirshipModuleVersion.h"
 
-static NSString *const tiAirshipModuleVersionString = @"7.0.0";
+static NSString *const tiAirshipModuleVersionString = @"7.1.0";
 
 @implementation TiAirshipModuleVersion
 

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 7.0.0
+version: 7.1.0
 apiversion: 2
 architectures: arm64 x86_64
 description: AirshipTitanium


### PR DESCRIPTION
### What do these changes do?
Update Titanium to iOS 13.5.4, Android 13.3.2. Update version numbers for release 7.1.0

### Why are these changes necessary?
Roll out new SDK updates.

### How did you verify these changes?
Local CI. Created sample app and received push on both iOS and Android.