### PR TITLE
Release 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Airship Titanium Module
 
-## Version 9.2.0 - April 3, 2023
+## Version 10.0.0 - April 6, 2023
 
-Minor release that updates to support Titanium 12.0.0.GA and latest Airship SDK versions.
+Major release that updates to support Titanium 12.0.0.GA and latest Airship SDK versions.
 
 ### Changes
 - Updated iOS SDK to 16.11.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Airship Titanium Module
 
+## Version 9.2.0 - April 3, 2023
+
+Minor release that updates to support Titanium 12.0.0.GA and latest Airship SDK versions.
+
+### Changes
+- Updated iOS SDK to 16.11.3
+- Updated Android SDK to 16.9.1
+- Updated Titanium to 12.0.0.GA
+- Fixed Contact update merge order, resolving a Preference Center bug that could lead to unexpected subscription states in some circumstances
+- Improved Scene/Survey accessibility and fixed a reporting bug related to form display events 
+
 ## Version 9.1.0 - August 11, 2022
 
 Minor release that updates Airship SDK versions.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  def airshipVersion = "16.7.0"
+  def airshipVersion = "16.9.1"
 
   // ADM & FCM push providers
   implementation "com.urbanairship.android:urbanairship-fcm:$airshipVersion"

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 9.2.0
+version: 10.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Airship Titanium module

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 9.1.0
+version: 9.2.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Airship Titanium module

--- a/android/src/ti/airship/TiAutopilot.kt
+++ b/android/src/ti/airship/TiAutopilot.kt
@@ -17,7 +17,7 @@ import ti.airship.utils.PluginStore
 class TiAutopilot : Autopilot() {
 
     companion object {
-        private const val VERSION = "9.2.0"
+        private const val VERSION = "10.0.0"
     }
 
     private var configOptions: AirshipConfigOptions? = null

--- a/android/src/ti/airship/TiAutopilot.kt
+++ b/android/src/ti/airship/TiAutopilot.kt
@@ -17,7 +17,7 @@ import ti.airship.utils.PluginStore
 class TiAutopilot : Autopilot() {
 
     companion object {
-        private const val VERSION = "9.1.0"
+        private const val VERSION = "9.2.0"
     }
 
     private var configOptions: AirshipConfigOptions? = null

--- a/android/src/ti/airship/utils/ConfigParser.kt
+++ b/android/src/ti/airship/utils/ConfigParser.kt
@@ -11,7 +11,6 @@ import com.urbanairship.json.JsonList
 import com.urbanairship.json.JsonMap
 import com.urbanairship.json.JsonValue
 import com.urbanairship.util.UAStringUtil
-import org.apache.log4j.lf5.LogLevel
 import ti.airship.TiAirshipModule
 
 object ConfigParser {

--- a/ios/Classes/TiAirshipAutopilot.swift
+++ b/ios/Classes/TiAirshipAutopilot.swift
@@ -8,7 +8,7 @@ import TitaniumKit
 
 @objc(TiAirshipAutopilot)
 public class TiAirshipAutopilot: NSObject {
-    private static let version = "9.1.0"
+    private static let version = "9.2.0"
 
     private static let airshipDelegate = TiAirshipDelegate()
 

--- a/ios/Classes/TiAirshipAutopilot.swift
+++ b/ios/Classes/TiAirshipAutopilot.swift
@@ -8,7 +8,7 @@ import TitaniumKit
 
 @objc(TiAirshipAutopilot)
 public class TiAirshipAutopilot: NSObject {
-    private static let version = "9.2.0"
+    private static let version = "10.0.0"
 
     private static let airshipDelegate = TiAirshipDelegate()
 

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 9.1.0
+version: 9.2.0
 apiversion: 2
 architectures: arm64 x86_64
 mac: true

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 9.2.0
+version: 10.0.0
 apiversion: 2
 architectures: arm64 x86_64
 mac: true

--- a/ios/ti.airship.podspec
+++ b/ios/ti.airship.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
     s.name         = "ti.airship"
-    s.version      = "9.1.0"
+    s.version      = "9.2.0"
     s.summary      = "The Airship Titanium module."
   
     s.description  = <<-DESC

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-IOS_VERSION='16.9.1'
+IOS_VERSION='16.11.3'
 ROOT_PATH=`dirname "${0}"`/..
 DOWNLOAD_DIRECTORY="$ROOT_PATH/build/download/iOS/$IOS_VERSION"
 

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -12,9 +12,9 @@ fi
 sed -i '' "s/\(^version:\).*/\1 $VERSION/g" $ROOT_PATH/ios/manifest
 sed -i '' "s/\(^version:\).*/\1 $VERSION/g" $ROOT_PATH/android/manifest
 
-# Android - TiAirshipModuleVersion.java
-sed -i '' "s/\(TI_AIRSHIP_MODULE_VERSION *= *\)\".*\"/\1\"$VERSION\"/g" $ROOT_PATH/android/src/ti/airship/TiAirshipModuleVersion.java
+# Android - TiAutopilot.kt
+sed -i '' "s/\(VERSION *= *\)\".*\"/\1\"$VERSION\"/g" $ROOT_PATH/android/src/ti/airship/TiAutopilot.kt
 
-# iOS - TiAirshipModuleVersion.m
-sed -i '' "s/\(tiAirshipModuleVersionString *= *@\)\".*\"/\1\"$VERSION\"/g" $ROOT_PATH/ios/Classes/TiAirshipModuleVersion.m
+# iOS - TiAirshipAutopilot.kt
+sed -i '' "s/\(version *= *\)\".*\"/\1\"$VERSION\"/g" $ROOT_PATH/ios/Classes/TiAirshipAutopilot.swift
 


### PR DESCRIPTION
## Version 10.0.0 - April 6, 2023

Major release that updates to support Titanium 12.0.0.GA and latest Airship SDK versions.

### Changes
- Updated iOS SDK to 16.11.3
- Updated Android SDK to 16.9.1
- Updated Titanium to 12.0.0.GA
- Fixed Contact update merge order, resolving a Preference Center bug that could lead to unexpected subscription states in some circumstances
- Improved Scene/Survey accessibility and fixed a reporting bug related to form display events 

### Other notes

- Also fixed up the `update_version.sh` script to point at the correct files